### PR TITLE
Protect against wrong usage for shift/pop

### DIFF
--- a/CircularBuffer.tpp
+++ b/CircularBuffer.tpp
@@ -66,6 +66,8 @@ bool CircularBuffer<T,S>::push(T value) {
 
 template<typename T, __CB_ST__ S> 
 T CircularBuffer<T,S>::shift() {
+        void(* crash) (void) = 0;
+        if (count <= 0) crash();
 	T result = *head++;
 	if (head == buffer + S) {
 		head = buffer;
@@ -76,6 +78,8 @@ T CircularBuffer<T,S>::shift() {
 
 template<typename T, __CB_ST__ S> 
 T CircularBuffer<T,S>::pop() {
+        void(* crash) (void) = 0;
+        if (count <= 0) crash();
 	T result = *tail--;
 	if (tail == buffer) {
 		tail = buffer + S - 1;

--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ buffer.push(-5);  // [2,3,2,1,-5] returns false
 ------------------------
 
 Similarly to data addition, data retrieval can be performed at _tail_ via a `pop()` operation or from _head_ via an `unshift()` operation: both cause the element being read to be removed from the buffer.
+Reading from an empty buffer is forbidden (the library will generate a segfault, which most probably will crash the program): see the _additional operations_ listed in the next section to verify the status of the buffer.
 
 Non-destructive read operations are also available:
 
@@ -77,7 +78,7 @@ Non-destructive read operations are also available:
 * `last()` return the element at _tail_
 * an array-like indexed read operation is also available so you can read any element in the buffer using the `[]` operator
 
-In all cases reading data beyond the actual buffer size has an undefined behaviour and is user's responsibility to prevent such boundary violations using the _additional operations_ listed in the next section.
+Reading data beyond the actual buffer size has an undefined behaviour and is user's responsibility to prevent such boundary violations using the _additional operations_ listed in the next section.
 
 ``` cpp
 CircularBuffer<char, 50> buffer; // ['a','b','c','d','e','f','g']


### PR DESCRIPTION
This version protects the library from undefined state when shitfing or poping from an empty buffer.

Since exceptions are not supported in arduino, in case of failure a segmentation fault is generated.

In this way the program will probably crashing alerting the user of some problem, instead of living the program running in an undefined state of the buffer.