### PR TITLE
Improved code style, removing invalid identifiers

### DIFF
--- a/CircularBuffer.h
+++ b/CircularBuffer.h
@@ -15,26 +15,26 @@
  You should have received a copy of the GNU General Public License
  along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-#ifndef __CIRCULAR_BUFFER__
-#define __CIRCULAR_BUFFER__
-#include <inttypes.h>
+#ifndef CIRCULAR_BUFFER_H_
+#define CIRCULAR_BUFFER_H_
+#include <stdint.h>
+#include <stddef.h>
 
 #ifndef CIRCULAR_BUFFER_XS
-#define __CB_ST__ uint16_t
+	using CircBufDefIndex = uint8_t;
 #else
-#define __CB_ST__ uint8_t
+	using CircBufDefIndex = uint16t_t;
 #endif
 
 #ifdef CIRCULAR_BUFFER_DEBUG
 #include <Print.h>
 #endif
 
-template<typename T, __CB_ST__ S> class CircularBuffer {
+template<typename T, size_t S, typename IT = CircBufDefIndex> class CircularBuffer {
 public:
+	static constexpr IT sizeM = static_cast<IT> (S);
 
-	CircularBuffer();
-
-	~CircularBuffer();
+	constexpr CircularBuffer();
 
 	/**
 	 * Adds an element to the beginning of buffer: the operation returns `false` if the addition caused overwriting an existing element.
@@ -69,22 +69,22 @@ public:
 	/**
 	 * Array-like access to buffer
 	 */
-	T operator [] (__CB_ST__ index);
+	T operator [] (IT index);
 
 	/**
 	 * Returns how many elements are actually stored in the buffer.
 	 */
-	__CB_ST__ inline size();
+	IT inline size();
 
 	/**
 	 * Returns how many elements can be safely pushed into the buffer.
 	 */
-	__CB_ST__ inline available();
+	IT inline available();
 
 	/**
 	 * Returns how many elements can be potentially stored into the buffer.
 	 */
-	__CB_ST__ inline capacity();
+	constexpr IT inline capacity();
 
 	/**
 	 * Returns `true` if no elements can be removed from the buffer.
@@ -111,9 +111,9 @@ private:
 	T *head;
 	T *tail;
 #ifndef CIRCULAR_BUFFER_INT_SAFE
-	__CB_ST__ count;
+	IT count;
 #else
-	volatile __CB_ST__ count;
+	volatile IT count;
 #endif
 };
 

--- a/CircularBuffer.tpp
+++ b/CircularBuffer.tpp
@@ -18,24 +18,20 @@
 
 #include <string.h>
 
-template<typename T, __CB_ST__ S> 
-CircularBuffer<T,S>::CircularBuffer() :
+template<typename T, size_t S, typename IT>
+constexpr CircularBuffer<T,S,IT>::CircularBuffer() :
 		head(buffer), tail(buffer), count(0) {
 }
 
-template<typename T, __CB_ST__ S> 
-CircularBuffer<T,S>::~CircularBuffer() {
-}
-
-template<typename T, __CB_ST__ S> 
-bool CircularBuffer<T,S>::unshift(T value) {
+template<typename T, size_t S, typename IT>
+bool CircularBuffer<T,S,IT>::unshift(T value) {
 	if (head == buffer) {
-		head = buffer + S;
+		head = buffer + sizeM;
 	}
 	*--head = value;
-	if (count == S) {
+	if (count == sizeM) {
 		if (tail-- == buffer) {
-			tail = buffer + S - 1;
+			tail = buffer + sizeM - 1;
 		}
 		return false;
 	} else {
@@ -46,14 +42,14 @@ bool CircularBuffer<T,S>::unshift(T value) {
 	}
 }
 
-template<typename T, __CB_ST__ S> 
-bool CircularBuffer<T,S>::push(T value) {
-	if (++tail == buffer + S) {
+template<typename T, size_t S, typename IT>
+bool CircularBuffer<T,S,IT>::push(T value) {
+	if (++tail == buffer + sizeM) {
 		tail = buffer;
 	}
 	*tail = value;
-	if (count == S) {
-		if (++head == buffer + S) {
+	if (count == sizeM) {
+		if (++head == buffer + sizeM) {
 			head = buffer;
 		}
 		return false;
@@ -65,80 +61,80 @@ bool CircularBuffer<T,S>::push(T value) {
 	}
 }
 
-template<typename T, __CB_ST__ S> 
-T CircularBuffer<T,S>::shift() {
+template<typename T, size_t S, typename IT>
+T CircularBuffer<T,S,IT>::shift() {
 	void(* crash) (void) = 0;
 	if (count <= 0) crash();
 	T result = *head++;
-	if (head >= buffer + S) {
+	if (head >= buffer + sizeM) {
 		head = buffer;
 	}
 	count--;
 	return result;
 }
 
-template<typename T, __CB_ST__ S> 
-T CircularBuffer<T,S>::pop() {
+template<typename T, size_t S, typename IT>
+T CircularBuffer<T,S,IT>::pop() {
 	void(* crash) (void) = 0;
 	if (count <= 0) crash();
 	T result = *tail--;
 	if (tail < buffer) {
-		tail = buffer + S - 1;
+		tail = buffer + sizeM - 1;
 	}
 	count--;
 	return result;
 }
 
-template<typename T, __CB_ST__ S> 
-T inline CircularBuffer<T,S>::first() {
+template<typename T, size_t S, typename IT>
+T inline CircularBuffer<T,S,IT>::first() {
 	return *head;
 }
 
-template<typename T, __CB_ST__ S> 
-T inline CircularBuffer<T,S>::last() {
+template<typename T, size_t S, typename IT>
+T inline CircularBuffer<T,S,IT>::last() {
 	return *tail;
 }
 
-template<typename T, __CB_ST__ S> 
-T CircularBuffer<T,S>::operator [](__CB_ST__ index) {
-	return *(buffer + ((head - buffer + index) % S));
+template<typename T, size_t S, typename IT>
+T CircularBuffer<T,S,IT>::operator [](IT index) {
+	return *(buffer + ((head - buffer + index) % sizeM));
 }
 
-template<typename T, __CB_ST__ S> 
-__CB_ST__ inline CircularBuffer<T,S>::size() {
+template<typename T, size_t S, typename IT>
+IT inline CircularBuffer<T,S,IT>::size() {
 	return count;
 }
 
-template<typename T, __CB_ST__ S> 
-__CB_ST__ inline CircularBuffer<T,S>::available() {
-	return S - count;
+template<typename T, size_t S, typename IT>
+IT inline CircularBuffer<T,S,IT>::available() {
+	return sizeM - count;
 }
 
-template<typename T, __CB_ST__ S> 
-__CB_ST__ inline CircularBuffer<T,S>::capacity() {
-	return S;
+template<typename T, size_t S, typename IT>
+constexpr IT inline CircularBuffer<T,S,IT>::capacity() {
+	return sizeM;
 }
 
-template<typename T, __CB_ST__ S> 
-bool inline CircularBuffer<T,S>::isEmpty() {
+template<typename T, size_t S, typename IT>
+bool inline CircularBuffer<T,S,IT>::isEmpty() {
 	return count == 0;
 }
 
-template<typename T, __CB_ST__ S> 
-bool inline CircularBuffer<T,S>::isFull() {
-	return count == S;
+template<typename T, size_t S, typename IT>
+bool inline CircularBuffer<T,S,IT>::isFull() {
+	return count == sizeM;
 }
 
-template<typename T, __CB_ST__ S> 
-void inline CircularBuffer<T,S>::clear() {
+template<typename T, size_t S, typename IT>
+void inline CircularBuffer<T,S,IT>::clear() {
 	head = tail = buffer;
 	count = 0;
 }
 
 #ifdef CIRCULAR_BUFFER_DEBUG
-template<typename T, __CB_ST__ S> 
-void inline CircularBuffer<T,S>::debug(Print* out) {
-	for (__CB_ST__ i = 0; i < S; i++) {
+template<typename T, size_t S, typename IT>
+void inline CircularBuffer<T,S,IT>::debug(Print* out) {
+	for (IT i = 0; i < sizeM; i++) {
 		int hex = (int)buffer + i;
 		out->print(hex, HEX);
 		out->print("  ");
@@ -153,9 +149,9 @@ void inline CircularBuffer<T,S>::debug(Print* out) {
 	}
 }
 
-template<typename T, __CB_ST__ S> 
-void inline CircularBuffer<T,S>::debugFn(Print* out, void (*printFunction)(Print*, T)) {
-	for (__CB_ST__ i = 0; i < S; i++) {
+template<typename T, size_t S, typename IT>
+void inline CircularBuffer<T,S,IT>::debugFn(Print* out, void (*printFunction)(Print*, T)) {
+	for (IT i = 0; i < sizeM; i++) {
 		int hex = (int)buffer + i;
 		out->print(hex, HEX);
 		out->print("  ");


### PR DESCRIPTION
Hello, in this PR I improved the coding style of your library a little. Particularly, identifiers with underscores are [forbidden](https://stackoverflow.com/a/228797), so I renamed them. I removed the `__CB_ST__` macro; instead I defined a type alias `CircBufDefIndex` as `uint8/16_t` (never use macros for types!). I added a template parameter for the index type, which defaults to `CircBufDefIndex`. This means that the API is backwards-compatible, but you can now use it as `CircularBuffer<int,3,uint8_t>` to specify the index type, in which case the `CIRCULAR_BUFFER_XS` macro is ignored. This means you can have both small and big buffers in _one_ source file. Also, the `inttypes.h` Header is superfluous, `stdint.h` and `stddef.h` (for `size_t`) are sufficient. We could also remove the `CIRCULAR_BUFFER_DEBUG` macro, because the compiler will optimize the debug functions out if they are not used anyways. For good measure, I also added some `constexpr`. The changes require C++11, which is the default in Arduino since version 1.6.6 (2015).

Greetings, Niklas