### PR TITLE
Autoidxtype

### DIFF
--- a/CircularBuffer.h
+++ b/CircularBuffer.h
@@ -30,7 +30,24 @@
 #include <Print.h>
 #endif
 
-template<typename T, size_t S, typename IT = DefaultIT> class CircularBuffer {
+namespace Helper {
+	template <bool Is8, bool Is16>
+	struct GetType {
+		using Type = uint32_t;
+	};
+
+	template<>
+	struct GetType<true, true> {
+		using Type = uint8_t;
+	};
+
+	template<>
+	struct GetType<false, true> {
+		using Type = uint16_t;
+	};
+}
+
+template<typename T, size_t S, typename IT = typename Helper::GetType<(S <= 255), (S <= 65535)>::Type> class CircularBuffer {
 public:
 	static constexpr IT capacity = static_cast<IT> (S);
 

--- a/CircularBuffer.h
+++ b/CircularBuffer.h
@@ -20,12 +20,6 @@
 #include <stdint.h>
 #include <stddef.h>
 
-#ifdef CIRCULAR_BUFFER_XS
-	using DefaultIT = uint8_t;
-#else
-	using DefaultIT = uint16_t;
-#endif
-
 #ifdef CIRCULAR_BUFFER_DEBUG
 #include <Print.h>
 #endif


### PR DESCRIPTION
Hi, as requested in #14, this change lets `CircularBuffer` automatically determine the index type based on the given size. If the size is <= 255, `uint8_t` is used; if it's <= 65535, `uint16_t` is used, and `uint32_t` else (this allows large buffers on ARM Arduinos). There are more elegant/portable ways based on `std::numeric_limits`, but since that is unavailable with AVR-GCC we can't use it here. The type is given as the default value for the 3rd template parameter; therefore the API still stays the same, and the index type can be manually overridden if desired. This makes `CIRCULAR_BUFFER_XS` and `DefaultIT` obsolete.