### PR TITLE
Calling element constructors/destructors

### DIFF
--- a/CircularBuffer.h
+++ b/CircularBuffer.h
@@ -133,6 +133,8 @@ public:
 private:
 	union Container {
 		T obj;
+		Container () {}
+		~Container () {}
 	} buffer[S], *head, *tail;
 #ifndef CIRCULAR_BUFFER_INT_SAFE
 	IT count;

--- a/CircularBuffer.h
+++ b/CircularBuffer.h
@@ -34,6 +34,8 @@ namespace Helper {
 	};
 }
 
+inline void *operator new(size_t, void *buf) { return buf; }
+	
 template<typename T, size_t S, typename IT = typename Helper::Index<(S <= UINT8_MAX)>::Type> class CircularBuffer {
 public:
 	static constexpr IT capacity = static_cast<IT>(S);
@@ -43,12 +45,14 @@ public:
 	/**
 	 * Adds an element to the beginning of buffer: the operation returns `false` if the addition caused overwriting an existing element.
 	 */
-	bool unshift(T value);
+	template <typename Obj>
+	bool unshift(Obj&& value);
 
 	/**
 	 * Adds an element to the end of buffer: the operation returns `false` if the addition caused overwriting an existing element.
 	 */
-	bool push(T value);
+	template <typename Obj>
+	bool push(Obj&& value);
 
 	/**
 	 * Removes an element from the beginning of the buffer.
@@ -63,17 +67,17 @@ public:
 	/**
 	 * Returns the element at the beginning of the buffer.
 	 */
-	T inline first();
+	inline T& first();
 
 	/**
 	 * Returns the element at the end of the buffer.
 	 */
-	T inline last();
+	inline T& last();
 
 	/**
 	 * Array-like access to buffer
 	 */
-	T operator [] (IT index);
+	T& operator [] (IT index);
 
 	/**
 	 * Returns how many elements are actually stored in the buffer.
@@ -102,13 +106,11 @@ public:
 
 	#ifdef CIRCULAR_BUFFER_DEBUG
 	void inline debug(Print* out);
-	void inline debugFn(Print* out, void (*printFunction)(Print*, T));
+	void inline debugFn(Print* out, void (*printFunction)(Print*, const T&));
 	#endif
 
 private:
-	T buffer[S];
-	T *head;
-	T *tail;
+	union { T obj; } buffer[S], *head, *tail;
 #ifndef CIRCULAR_BUFFER_INT_SAFE
 	IT count;
 #else
@@ -116,5 +118,5 @@ private:
 #endif
 };
 
-#include <CircularBuffer.tpp>
+#include "./CircularBuffer.tpp"
 #endif

--- a/CircularBuffer.h
+++ b/CircularBuffer.h
@@ -62,18 +62,28 @@ public:
 	using index_t = IT;
 
 	CircularBuffer();
+	~CircularBuffer ();
+	CircularBuffer(const CircularBuffer& src);
+	CircularBuffer(CircularBuffer&& src);
+	CircularBuffer& operator = (const CircularBuffer& src);
+	CircularBuffer& operator = (CircularBuffer&& src);
+	
 
 	/**
 	 * Adds an element to the beginning of buffer: the operation returns `false` if the addition caused overwriting an existing element.
 	 */
-	template <typename Obj>
-	bool unshift(Obj&& value);
+	bool unshift(const T& value);
+	bool unshift(T&& value);
+	template <typename... Args>
+	bool unshift_emplace(Args&&... args);
 
 	/**
 	 * Adds an element to the end of buffer: the operation returns `false` if the addition caused overwriting an existing element.
 	 */
-	template <typename Obj>
-	bool push(Obj&& value);
+	bool push(const T& value);
+	bool push(T&& value);
+	template <typename... Args>
+	bool push_emplace(Args&&... args);
 
 	/**
 	 * Removes an element from the beginning of the buffer.
@@ -96,19 +106,34 @@ public:
 	inline T& last();
 
 	/**
+	 * Returns the element at the beginning of the buffer.
+	 */
+	inline const T& first() const;
+
+	/**
+	 * Returns the element at the end of the buffer.
+	 */
+	inline const T& last() const;
+
+	/**
 	 * Array-like access to buffer
 	 */
 	T& operator [] (IT index);
 
 	/**
+	 * Array-like access to buffer
+	 */
+	const T& operator [] (IT index) const;
+
+	/**
 	 * Returns how many elements are actually stored in the buffer.
 	 */
-	IT inline size();
+	IT inline size() const;
 
 	/**
 	 * Returns how many elements can be safely pushed into the buffer.
 	 */
-	IT inline available();
+	IT inline available() const;
 
 	/**
 	 * Returns `true` if no elements can be removed from the buffer.
@@ -126,16 +151,19 @@ public:
 	void inline clear();
 
 	#ifdef CIRCULAR_BUFFER_DEBUG
-	void inline debug(Print* out);
-	void inline debugFn(Print* out, void (*printFunction)(Print*, const T&));
+	void inline debug(Print* out) const;
+	void inline debugFn(Print* out, void (*printFunction)(Print*, const T&)) const;
 	#endif
 
 private:
+	T* unshift (bool& res);
+	T* push (bool& res);
 	union Container {
 		T obj;
 		Container () {}
 		~Container () {}
-	} buffer[S], *head, *tail;
+	} buffer[S];
+	size_t head, tail;
 #ifndef CIRCULAR_BUFFER_INT_SAFE
 	IT count;
 #else

--- a/CircularBuffer.h
+++ b/CircularBuffer.h
@@ -53,7 +53,7 @@ template<typename T, size_t S, typename IT = typename Helper::Index<(S <= UINT8_
 public:
 	static constexpr IT capacity = static_cast<IT>(S);
 
-	constexpr CircularBuffer();
+	CircularBuffer();
 
 	/**
 	 * Adds an element to the beginning of buffer: the operation returns `false` if the addition caused overwriting an existing element.
@@ -105,12 +105,12 @@ public:
 	/**
 	 * Returns `true` if no elements can be removed from the buffer.
 	 */
-	bool inline isEmpty();
+	bool inline isEmpty() const;
 
 	/**
 	 * Returns `true` if no elements can be added to the buffer without overwriting existing elements.
 	 */
-	bool inline isFull();
+	bool inline isFull() const;
 
 	/**
 	 * Resets the buffer to a clean status, making all buffer positions available.
@@ -125,9 +125,6 @@ public:
 private:
 	union Container {
 		T obj;
-		struct {} dummy;
-		constexpr Container () : dummy {} {}
-		~Container () {}
 	} buffer[S], *head, *tail;
 #ifndef CIRCULAR_BUFFER_INT_SAFE
 	IT count;

--- a/CircularBuffer.tpp
+++ b/CircularBuffer.tpp
@@ -17,8 +17,8 @@
  */
 
 template<typename T, size_t S, typename IT>
-constexpr CircularBuffer<T,S,IT>::CircularBuffer() :
-		head(buffer), tail(buffer), count(0) {
+CircularBuffer<T,S,IT>::CircularBuffer() :
+	head(buffer), tail(buffer), count(0) {
 }
 
 template<typename T, size_t S, typename IT>
@@ -119,12 +119,12 @@ IT inline CircularBuffer<T,S,IT>::available() {
 }
 
 template<typename T, size_t S, typename IT>
-bool inline CircularBuffer<T,S,IT>::isEmpty() {
+bool inline CircularBuffer<T,S,IT>::isEmpty() const {
 	return count == 0;
 }
 
 template<typename T, size_t S, typename IT>
-bool inline CircularBuffer<T,S,IT>::isFull() {
+bool inline CircularBuffer<T,S,IT>::isFull() const {
 	return count == capacity;
 }
 


### PR DESCRIPTION
This PR lets the buffer automatically call constructors/destructors of elements properly, fixing #12 (if I understood it correctly). This allows users to place class objects in the buffer which do something in these functions, e.g. allocate memory in the c'tor and free it in the d'tor; with this PR, memory is freed correctly when the element is removed.
This is achieved by placing the elements inside a `union`, which does not call constructors/destructors automatically. There is however an AVR-specific problem: For calling the constructor explicitly, the placement-new syntax has to be used. For this to work, an overload for `operator new` is required, which is provided by the `<new>` header. Since AVR-GCC does not ship with standard c++ headers, we have to provide our own overload. It is just one line, but that might collide with other libraries which do the same. Therefore, I added a comment to have the user comment out the line in case of a problem. This is only done for AVR, as the ARM-GCC does provide `<new>`.
The parameter type for `unshift` and `push` is now an "[universal reference](https://isocpp.org/blog/2012/11/universal-references-in-c11-scott-meyers)" to allow passing arbitrary objects to the element constructor.
The additions should not incur any overhead for types with trivial c'tors/d'tors such as integers. The code compiles, but I did not test it on actual hardware.