### PR TITLE
Implement pass by reference for large objects

### DIFF
--- a/CircularBuffer.h
+++ b/CircularBuffer.h
@@ -39,6 +39,16 @@ namespace Helper {
 	template<> struct Index<true, true> {
 		using Type = uint8_t;
 	};
+
+	/** @private */
+	template<typename T, bool USEREF> struct Param {
+		using Type = T;
+	};
+
+	/** @private */
+	template<typename T> struct Param<T, true> {
+		using Type = const T &;
+	};
 }
 
 /**
@@ -47,8 +57,11 @@ namespace Helper {
  * @tparam T The type of the data to store in the buffer.
  * @tparam S The maximum number of elements that can be stored in the buffer.
  * @tparam IT The data type of the index. Typically should be left as default.
+ * @tparam TIn Input type to push() and unshift().
  */
-template<typename T, size_t S, typename IT = typename Helper::Index<(S <= UINT8_MAX), (S <= UINT16_MAX)>::Type> class CircularBuffer {
+template<typename T, size_t S, typename IT = typename Helper::Index<(S <= UINT8_MAX), (S <= UINT16_MAX)>::Type,
+typename TIn = typename Helper::Param<T, (sizeof(T) > 2 * sizeof(void *))>::Type>
+class CircularBuffer {
 public:
 	/**
 	 * @brief The buffer capacity.
@@ -83,17 +96,21 @@ public:
 
 	/**
 	 * @brief Adds an element to the beginning of buffer.
+	 * 
+	 * Value is passed by reference if the type is bigger than 2 * sizeof(void *).
 	 *
 	 * @return `false` iff the addition caused overwriting to an existing element.
 	 */
-	bool unshift(T value);
+	bool unshift(TIn value);
 
 	/**
 	 * @brief Adds an element to the end of buffer.
+	 * 
+	 * Value is passed by reference if the type is bigger than 2 * sizeof(void *).
 	 *
 	 * @return `false` iff the addition caused overwriting to an existing element.
 	 */
-	bool push(T value);
+	bool push(TIn value);
 
 	/**
 	 * @brief Removes an element from the beginning of the buffer.
@@ -103,11 +120,25 @@ public:
 	T shift();
 
 	/**
+	 * @brief Removes an element from the beginning of the buffer.
+	 *
+	 * @warning Calling this operation on an empty buffer has an unpredictable behaviour.
+	 */
+	void shift(T &);
+
+	/**
 	 * @brief Removes an element from the end of the buffer.
 	 *
 	 * @warning Calling this operation on an empty buffer has an unpredictable behaviour.
 	 */
 	T pop();
+
+	/**
+	 * @brief Removes an element from the end of the buffer.
+	 *
+	 * @warning Calling this operation on an empty buffer has an unpredictable behaviour.
+	 */
+	void pop(T &);
 
 	/**
 	 * @brief Returns the element at the beginning of the buffer.
@@ -117,11 +148,25 @@ public:
 	T inline first() const;
 
 	/**
+	 * @brief Returns the element at the beginning of the buffer.
+	 *
+	 * @return The element at the beginning of the buffer.
+	 */
+	void inline first(T &) const;
+
+	/**
 	 * @brief Returns the element at the end of the buffer.
 	 *
 	 * @return The element at the end of the buffer.
 	 */
 	T inline last() const;
+
+	/**
+	 * @brief Returns the element at the end of the buffer.
+	 *
+	 * @return The element at the end of the buffer.
+	 */
+	void inline last(T &) const;
 
 	/**
 	 * @brief Array-like access to buffer.

--- a/CircularBuffer.h
+++ b/CircularBuffer.h
@@ -41,12 +41,12 @@ namespace Helper {
 	};
 
 	/** @private */
-	template<typename T, bool USEREF> struct Param {
+	template<typename T, bool USEREF> struct Input {
 		using Type = T;
 	};
 
 	/** @private */
-	template<typename T> struct Param<T, true> {
+	template<typename T> struct Input<T, true> {
 		using Type = const T &;
 	};
 }
@@ -60,7 +60,7 @@ namespace Helper {
  * @tparam TIn Input type to push() and unshift().
  */
 template<typename T, size_t S, typename IT = typename Helper::Index<(S <= UINT8_MAX), (S <= UINT16_MAX)>::Type,
-typename TIn = typename Helper::Param<T, (sizeof(T) > 2 * sizeof(void *))>::Type>
+typename TIn = typename Helper::Input<T, (sizeof(T) > 2 * sizeof(void *))>::Type>
 class CircularBuffer {
 public:
 	/**

--- a/CircularBuffer.tpp
+++ b/CircularBuffer.tpp
@@ -16,13 +16,13 @@
  along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-template<typename T, size_t S, typename IT>
-constexpr CircularBuffer<T,S,IT>::CircularBuffer() :
+template<typename T, size_t S, typename IT, typename TIn>
+constexpr CircularBuffer<T,S,IT, TIn>::CircularBuffer() :
 		head(buffer), tail(buffer), count(0) {
 }
 
-template<typename T, size_t S, typename IT>
-bool CircularBuffer<T,S,IT>::unshift(T value) {
+template<typename T, size_t S, typename IT, typename TIn>
+bool CircularBuffer<T,S,IT,TIn>::unshift(TIn value) {
 	if (head == buffer) {
 		head = buffer + capacity;
 	}
@@ -40,8 +40,8 @@ bool CircularBuffer<T,S,IT>::unshift(T value) {
 	}
 }
 
-template<typename T, size_t S, typename IT>
-bool CircularBuffer<T,S,IT>::push(T value) {
+template<typename T, size_t S, typename IT, typename TIn>
+bool CircularBuffer<T,S,IT, TIn>::push(TIn value) {
 	if (++tail == buffer + capacity) {
 		tail = buffer;
 	}
@@ -59,8 +59,8 @@ bool CircularBuffer<T,S,IT>::push(T value) {
 	}
 }
 
-template<typename T, size_t S, typename IT>
-T CircularBuffer<T,S,IT>::shift() {
+template<typename T, size_t S, typename IT, typename TIn>
+T CircularBuffer<T,S,IT, TIn>::shift() {
 	if (count == 0) return *head;
 	T result = *head++;
 	if (head >= buffer + capacity) {
@@ -70,8 +70,8 @@ T CircularBuffer<T,S,IT>::shift() {
 	return result;
 }
 
-template<typename T, size_t S, typename IT>
-T CircularBuffer<T,S,IT>::pop() {
+template<typename T, size_t S, typename IT, typename TIn>
+T CircularBuffer<T,S,IT, TIn>::pop() {
 	if (count == 0) return *tail;
 	T result = *tail--;
 	if (tail < buffer) {
@@ -81,52 +81,62 @@ T CircularBuffer<T,S,IT>::pop() {
 	return result;
 }
 
-template<typename T, size_t S, typename IT>
-T inline CircularBuffer<T,S,IT>::first() const {
+template<typename T, size_t S, typename IT, typename TIn>
+T inline CircularBuffer<T,S,IT, TIn>::first() const {
 	return *head;
 }
 
-template<typename T, size_t S, typename IT>
-T inline CircularBuffer<T,S,IT>::last() const {
+template<typename T, size_t S, typename IT, typename TIn>
+void inline CircularBuffer<T,S,IT, TIn>::first(T &value) const {
+	value = *head;
+}
+
+template<typename T, size_t S, typename IT, typename TIn>
+T inline CircularBuffer<T,S,IT, TIn>::last() const {
 	return *tail;
 }
 
-template<typename T, size_t S, typename IT>
-T CircularBuffer<T,S,IT>::operator [](IT index) const {
+template<typename T, size_t S, typename IT, typename TIn>
+void inline CircularBuffer<T,S,IT, TIn>::last(T &value) const {
+	value = *tail;
+}
+
+template<typename T, size_t S, typename IT, typename TIn>
+T CircularBuffer<T,S,IT, TIn>::operator [](IT index) const {
 	if (index >= count) return *tail;
 	return *(buffer + ((head - buffer + index) % capacity));
 }
 
-template<typename T, size_t S, typename IT>
-IT inline CircularBuffer<T,S,IT>::size() const {
+template<typename T, size_t S, typename IT, typename TIn>
+IT inline CircularBuffer<T,S,IT, TIn>::size() const {
 	return count;
 }
 
-template<typename T, size_t S, typename IT>
-IT inline CircularBuffer<T,S,IT>::available() const {
+template<typename T, size_t S, typename IT, typename TIn>
+IT inline CircularBuffer<T,S,IT, TIn>::available() const {
 	return capacity - count;
 }
 
-template<typename T, size_t S, typename IT>
-bool inline CircularBuffer<T,S,IT>::isEmpty() const {
+template<typename T, size_t S, typename IT, typename TIn>
+bool inline CircularBuffer<T,S,IT, TIn>::isEmpty() const {
 	return count == 0;
 }
 
-template<typename T, size_t S, typename IT>
-bool inline CircularBuffer<T,S,IT>::isFull() const {
+template<typename T, size_t S, typename IT, typename TIn>
+bool inline CircularBuffer<T,S,IT, TIn>::isFull() const {
 	return count == capacity;
 }
 
-template<typename T, size_t S, typename IT>
-void inline CircularBuffer<T,S,IT>::clear() {
+template<typename T, size_t S, typename IT, typename TIn>
+void inline CircularBuffer<T,S,IT, TIn>::clear() {
 	head = tail = buffer;
 	count = 0;
 }
 
 #ifdef CIRCULAR_BUFFER_DEBUG
 #include <string.h>
-template<typename T, size_t S, typename IT>
-void inline CircularBuffer<T,S,IT>::debug(Print* out) {
+template<typename T, size_t S, typename IT, typename TIn>
+void inline CircularBuffer<T,S,IT, TIn>::debug(Print* out) {
 	for (IT i = 0; i < capacity; i++) {
 		int hex = (int)buffer + i;
 		out->print("[");
@@ -143,8 +153,8 @@ void inline CircularBuffer<T,S,IT>::debug(Print* out) {
 	}
 }
 
-template<typename T, size_t S, typename IT>
-void inline CircularBuffer<T,S,IT>::debugFn(Print* out, void (*printFunction)(Print*, T)) {
+template<typename T, size_t S, typename IT, typename TIn>
+void inline CircularBuffer<T,S,IT, TIn>::debugFn(Print* out, void (*printFunction)(Print*, T)) {
 	for (IT i = 0; i < capacity; i++) {
 		int hex = (int)buffer + i;
 		out->print("[");

--- a/CircularBuffer.tpp
+++ b/CircularBuffer.tpp
@@ -71,6 +71,19 @@ T CircularBuffer<T,S,IT, TIn>::shift() {
 }
 
 template<typename T, size_t S, typename IT, typename TIn>
+void CircularBuffer<T,S,IT, TIn>::shift(T &result) {
+	if (count == 0) {
+		result = *head;
+	} else {
+		result = *head++;
+		if (head >= buffer + capacity) {
+			head = buffer;
+		}
+		count--;
+	}
+}
+
+template<typename T, size_t S, typename IT, typename TIn>
 T CircularBuffer<T,S,IT, TIn>::pop() {
 	if (count == 0) return *tail;
 	T result = *tail--;
@@ -79,6 +92,19 @@ T CircularBuffer<T,S,IT, TIn>::pop() {
 	}
 	count--;
 	return result;
+}
+
+template<typename T, size_t S, typename IT, typename TIn>
+void CircularBuffer<T,S,IT, TIn>::pop(T &result) {
+	if (count == 0) {
+		result = *tail;
+	} else {
+		result = *tail--;
+		if (tail < buffer) {
+			tail = buffer + capacity - 1;
+		}
+		count--;
+	}
 }
 
 template<typename T, size_t S, typename IT, typename TIn>

--- a/examples/Benchmark/Benchmark.ino
+++ b/examples/Benchmark/Benchmark.ino
@@ -60,7 +60,7 @@ void testPush()
   {
     Serial.println("Error!");
   }
-  
+
   // Prevent compiler from optimizing things out
   dummyByte = b.buf[0];
 
@@ -212,6 +212,16 @@ void setup() {
   testPopRef<16>();
 
   Serial.println();
+
+  // Output on a Arduino Mega clone
+  // Push By Value Timings
+  // 64,68,72,78,166,181,210,227,250,267,292,298,321,336,359,374,
+  // Push By Reference Timings
+  // 59,60,64,68,86,120,127,134,145,148,155,162,169,176,183,190,
+  // Pop By Value Timings
+  // 47,53,61,73,209,221,247,268,301,324,347,359,380,401,422,443,
+  // Pop By Reference Timings
+  // 37,41,45,49,67,90,97,104,111,118,125,132,139,146,153,160,
 }
 
 void loop() {

--- a/examples/Benchmark/Benchmark.ino
+++ b/examples/Benchmark/Benchmark.ino
@@ -1,0 +1,218 @@
+#include <CircularBuffer.h>
+
+volatile uint8_t dummyByte = 5;
+
+// Make a template object that is size bytes
+template<uint8_t size>
+struct Obj
+{
+  Obj()
+  {
+    for (uint8_t i = 0; i < size; i++)
+    {
+      buf[i] = dummyByte++;
+    }
+  }
+
+  uint8_t buf[size];
+
+  bool operator!=(Obj<size> &rhs)
+  {
+    for (uint8_t i = 0; i < size; i++)
+    {
+      if (buf[i] != rhs.buf[i])
+      {
+        return true;
+      }
+    }
+
+    return false;
+  }
+
+  Obj<size> operator=(uint8_t rhs)
+  {
+    buf[0] = rhs;
+  }
+
+  operator uint8_t()
+  {
+    return buf[0];
+  }
+};
+
+template<typename T, typename TIn>
+void testPush()
+{
+  uint16_t start, end;
+
+  CircularBuffer<T, 10, uint8_t, TIn> buf;
+
+  T a, b;
+  
+  noInterrupts();
+  start = TCNT1;
+  buf.push(a);
+  end = TCNT1;
+  interrupts();
+
+  b = buf.pop();
+  if (b != a)
+  {
+    Serial.println("Error!");
+  }
+  
+  // Prevent compiler from optimizing things out
+  dummyByte = b.buf[0];
+
+  // End - start is the number of clock cycles that the operation took,
+  // plus the number of cycles to read the counter, which is usually around
+  // 2 to 4 cycles, depending on how the compiler chooses to compile this
+  Serial.print(end - start);
+  Serial.print(",");
+}
+
+// Recursively define template to test pushing objects of size 1 through size
+template<uint8_t size>
+void testPushRef()
+{
+  testPushRef<size - 1>();
+  testPush<Obj<size>, const Obj<size> &>();
+}
+
+template<>
+void testPushRef<0>() {}
+
+template<uint8_t size>
+void testPushVal()
+{
+  testPushVal<size - 1>();
+  testPush<Obj<size>, const Obj<size>>();
+}
+
+template<>
+void testPushVal<0>() {}
+
+
+
+
+
+template<typename T>
+void testPopByRefImpl()
+{
+  uint16_t start, end;
+
+  CircularBuffer<T, 10, uint8_t, T> buf;
+
+  T a, b;
+  buf.push(a);
+  
+  noInterrupts();
+  start = TCNT1;
+  buf.pop(b);
+  end = TCNT1;
+  interrupts();
+
+  if (b != a)
+  {
+    Serial.println("Error!");
+  }
+
+  // Prevent compiler from optimizing things out
+  dummyByte = b.buf[0];
+
+  // End - start is the number of clock cycles that the operation took,
+  // plus the number of cycles to read the counter, which is usually around
+  // 2 to 4 cycles, depending on how the compiler chooses to compile this
+  Serial.print(end - start);
+  Serial.print(",");
+}
+
+// Recursively define template to test pushing objects of size 1 through size
+template<uint8_t size>
+void testPopRef()
+{
+  testPopRef<size - 1>();
+  testPopByRefImpl<Obj<size>>();
+}
+
+template<>
+void testPopRef<0>() {}
+
+
+
+
+template<typename T>
+void testPopByValImpl()
+{
+  uint16_t start, end;
+
+  CircularBuffer<T, 10, uint8_t, T> buf;
+
+  T a, b;
+  buf.push(a);
+  
+  noInterrupts();
+  start = TCNT1;
+  b = buf.pop();
+  end = TCNT1;
+  interrupts();
+
+  if (b != a)
+  {
+    Serial.println("Error!");
+  }
+  
+  // Prevent compiler from optimizing things out
+  dummyByte = b.buf[0];
+
+  // End - start is the number of clock cycles that the operation took,
+  // plus the number of cycles to read the counter, which is usually around
+  // 2 to 4 cycles, depending on how the compiler chooses to compile this
+  Serial.print(end - start);
+  Serial.print(",");
+}
+
+template<uint8_t size>
+void testPopVal()
+{
+  testPopVal<size - 1>();
+  testPopByValImpl<Obj<size>>();
+}
+
+template<>
+void testPopVal<0>() {}
+
+
+
+
+
+
+void setup() {
+	Serial.begin(9600);
+
+  // Set Timer 1 in normal counting mode, at the clock speed
+  // This lets us count the individual clock cycles for each operation
+  TCCR1A = 0;
+  TCCR1B = 1;
+
+  Serial.println();
+  Serial.println("Push By Value Timings");
+  testPushVal<16>();
+  
+  Serial.println();
+  Serial.println("Push By Reference Timings");
+  testPushRef<16>();
+
+  Serial.println();
+  Serial.println("Pop By Value Timings");
+  testPopVal<16>();
+  
+  Serial.println();
+  Serial.println("Pop By Reference Timings");
+  testPopRef<16>();
+
+  Serial.println();
+}
+
+void loop() {
+}


### PR DESCRIPTION
Detect when the item type T is large and use pass-by-reference instead of pass-by-value for push() and unshift(). This should be faster for large objects, per the [C++ Core Guidelines F.16](https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#f16-for-in-parameters-pass-cheaply-copied-types-by-value-and-others-by-reference-to-const). Additionally, provide implementations of pop(), shift(), first(), and last() that take a reference parameter for these large types.

This feature is implemented similarly to the IT parameter. The new template parameter TIn stores the input type for push() and unshift(). The TIn parameter defaults to the newly created Helper::Input::Type, which is `T` when `sizeof(T) <= 2*sizeof(void *)`, and is `const T &` when `sizeof(T) > 2*sizeof(void *)`. The other access methods are unchanged, although new versions are provided that take a reference to avoid having to return large objects, if desired by the caller.