### PR TITLE
Renamed classes to avoid conflict with Arduino bundled CircularBuffer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store

--- a/RLG_CircularBuffer.h
+++ b/RLG_CircularBuffer.h
@@ -1,5 +1,5 @@
 /*
- CircularBuffer.h - Circular buffer library for Arduino.
+ RLG_CircularBuffer.h - Circular buffer library for Arduino.
  Copyright (c) 2017 Roberto Lo Giacco.
 
  This program is free software: you can redistribute it and/or modify
@@ -15,12 +15,12 @@
  You should have received a copy of the GNU General Public License
  along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-#ifndef CIRCULAR_BUFFER_H_
-#define CIRCULAR_BUFFER_H_
+#ifndef RLG_CIRCULAR_BUFFER_H_
+#define RLG_CIRCULAR_BUFFER_H_
 #include <stdint.h>
 #include <stddef.h>
 
-#ifdef CIRCULAR_BUFFER_DEBUG
+#ifdef RLG_CIRCULAR_BUFFER_DEBUG
 #include <Print.h>
 #endif
 
@@ -48,7 +48,7 @@ namespace Helper {
  * @tparam S The maximum number of elements that can be stored in the buffer.
  * @tparam IT The data type of the index. Typically should be left as default.
  */
-template<typename T, size_t S, typename IT = typename Helper::Index<(S <= UINT8_MAX), (S <= UINT16_MAX)>::Type> class CircularBuffer {
+template<typename T, size_t S, typename IT = typename Helper::Index<(S <= UINT8_MAX), (S <= UINT16_MAX)>::Type> class RLG_CircularBuffer {
 public:
 	/**
 	 * @brief The buffer capacity.
@@ -67,19 +67,19 @@ public:
 	/**
 	 * @brief Create an empty circular buffer.
 	 */
-	constexpr CircularBuffer();
+	constexpr RLG_CircularBuffer();
 
 	// disable the copy constructor
 	/** @private */
-	CircularBuffer(const CircularBuffer&) = delete;
+	RLG_CircularBuffer(const RLG_CircularBuffer&) = delete;
 	/** @private */
-	CircularBuffer(CircularBuffer&&) = delete;
+	RLG_CircularBuffer(RLG_CircularBuffer&&) = delete;
 
 	// disable the assignment operator
 	/** @private */
-	CircularBuffer& operator=(const CircularBuffer&) = delete;
+	RLG_CircularBuffer& operator=(const RLG_CircularBuffer&) = delete;
 	/** @private */
-	CircularBuffer& operator=(CircularBuffer&&) = delete;
+	RLG_CircularBuffer& operator=(RLG_CircularBuffer&&) = delete;
 
 	/**
 	 * @brief Adds an element to the beginning of buffer.
@@ -184,5 +184,5 @@ private:
 #endif
 };
 
-#include <CircularBuffer.tpp>
+#include <RLG_CircularBuffer.tpp>
 #endif

--- a/RLG_CircularBuffer.h
+++ b/RLG_CircularBuffer.h
@@ -168,7 +168,7 @@ public:
 	 */
 	void inline clear();
 
-	#ifdef CIRCULAR_BUFFER_DEBUG
+	#ifdef RLG_CIRCULAR_BUFFER_DEBUG
 	void inline debug(Print* out);
 	void inline debugFn(Print* out, void (*printFunction)(Print*, T));
 	#endif
@@ -177,7 +177,7 @@ private:
 	T buffer[S];
 	T *head;
 	T *tail;
-#ifndef CIRCULAR_BUFFER_INT_SAFE
+#ifndef RLG_CIRCULAR_BUFFER_INT_SAFE
 	IT count;
 #else
 	volatile IT count;

--- a/RLG_CircularBuffer.tpp
+++ b/RLG_CircularBuffer.tpp
@@ -1,5 +1,5 @@
 /*
- CircularBuffer.tpp - Circular buffer library for Arduino.
+ RLG_CircularBuffer.tpp - Circular buffer library for Arduino.
  Copyright (c) 2017 Roberto Lo Giacco.
 
  This program is free software: you can redistribute it and/or modify
@@ -17,12 +17,12 @@
  */
 
 template<typename T, size_t S, typename IT>
-constexpr CircularBuffer<T,S,IT>::CircularBuffer() :
+constexpr RLG_CircularBuffer<T,S,IT>::RLG_CircularBuffer() :
 		head(buffer), tail(buffer), count(0) {
 }
 
 template<typename T, size_t S, typename IT>
-bool CircularBuffer<T,S,IT>::unshift(T value) {
+bool RLG_CircularBuffer<T,S,IT>::unshift(T value) {
 	if (head == buffer) {
 		head = buffer + capacity;
 	}
@@ -41,7 +41,7 @@ bool CircularBuffer<T,S,IT>::unshift(T value) {
 }
 
 template<typename T, size_t S, typename IT>
-bool CircularBuffer<T,S,IT>::push(T value) {
+bool RLG_CircularBuffer<T,S,IT>::push(T value) {
 	if (++tail == buffer + capacity) {
 		tail = buffer;
 	}
@@ -60,7 +60,7 @@ bool CircularBuffer<T,S,IT>::push(T value) {
 }
 
 template<typename T, size_t S, typename IT>
-T CircularBuffer<T,S,IT>::shift() {
+T RLG_CircularBuffer<T,S,IT>::shift() {
 	if (count == 0) return *head;
 	T result = *head++;
 	if (head >= buffer + capacity) {
@@ -71,7 +71,7 @@ T CircularBuffer<T,S,IT>::shift() {
 }
 
 template<typename T, size_t S, typename IT>
-T CircularBuffer<T,S,IT>::pop() {
+T RLG_CircularBuffer<T,S,IT>::pop() {
 	if (count == 0) return *tail;
 	T result = *tail--;
 	if (tail < buffer) {
@@ -82,43 +82,43 @@ T CircularBuffer<T,S,IT>::pop() {
 }
 
 template<typename T, size_t S, typename IT>
-T inline CircularBuffer<T,S,IT>::first() const {
+T inline RLG_CircularBuffer<T,S,IT>::first() const {
 	return *head;
 }
 
 template<typename T, size_t S, typename IT>
-T inline CircularBuffer<T,S,IT>::last() const {
+T inline RLG_CircularBuffer<T,S,IT>::last() const {
 	return *tail;
 }
 
 template<typename T, size_t S, typename IT>
-T CircularBuffer<T,S,IT>::operator [](IT index) const {
+T RLG_CircularBuffer<T,S,IT>::operator [](IT index) const {
 	if (index >= count) return *tail;
 	return *(buffer + ((head - buffer + index) % capacity));
 }
 
 template<typename T, size_t S, typename IT>
-IT inline CircularBuffer<T,S,IT>::size() const {
+IT inline RLG_CircularBuffer<T,S,IT>::size() const {
 	return count;
 }
 
 template<typename T, size_t S, typename IT>
-IT inline CircularBuffer<T,S,IT>::available() const {
+IT inline RLG_CircularBuffer<T,S,IT>::available() const {
 	return capacity - count;
 }
 
 template<typename T, size_t S, typename IT>
-bool inline CircularBuffer<T,S,IT>::isEmpty() const {
+bool inline RLG_CircularBuffer<T,S,IT>::isEmpty() const {
 	return count == 0;
 }
 
 template<typename T, size_t S, typename IT>
-bool inline CircularBuffer<T,S,IT>::isFull() const {
+bool inline RLG_CircularBuffer<T,S,IT>::isFull() const {
 	return count == capacity;
 }
 
 template<typename T, size_t S, typename IT>
-void inline CircularBuffer<T,S,IT>::clear() {
+void inline RLG_CircularBuffer<T,S,IT>::clear() {
 	head = tail = buffer;
 	count = 0;
 }
@@ -126,7 +126,7 @@ void inline CircularBuffer<T,S,IT>::clear() {
 #ifdef CIRCULAR_BUFFER_DEBUG
 #include <string.h>
 template<typename T, size_t S, typename IT>
-void inline CircularBuffer<T,S,IT>::debug(Print* out) {
+void inline RLG_CircularBuffer<T,S,IT>::debug(Print* out) {
 	for (IT i = 0; i < capacity; i++) {
 		int hex = (int)buffer + i;
 		out->print("[");
@@ -144,7 +144,7 @@ void inline CircularBuffer<T,S,IT>::debug(Print* out) {
 }
 
 template<typename T, size_t S, typename IT>
-void inline CircularBuffer<T,S,IT>::debugFn(Print* out, void (*printFunction)(Print*, T)) {
+void inline RLG_CircularBuffer<T,S,IT>::debugFn(Print* out, void (*printFunction)(Print*, T)) {
 	for (IT i = 0; i < capacity; i++) {
 		int hex = (int)buffer + i;
 		out->print("[");

--- a/examples/CircularBuffer/CircularBuffer.ino
+++ b/examples/CircularBuffer/CircularBuffer.ino
@@ -1,6 +1,6 @@
-#include <CircularBuffer.h>
+#include <RLG_CircularBuffer.h>
 
-CircularBuffer<int, 100> buffer;
+RLG_CircularBuffer<int, 100> buffer;
 
 unsigned long time = 0;
 

--- a/examples/EventLogging/EventLogging.ino
+++ b/examples/EventLogging/EventLogging.ino
@@ -1,9 +1,9 @@
-#include "CircularBuffer.h"
+#include "RLG_CircularBuffer.h"
 
 // the type of the record is unsigned long: we intend to store milliseconds
 // the buffer can contain up to 10 records
 // the buffer will use a byte for its index to reduce memory footprint
-CircularBuffer<unsigned long, 10> buffer;
+RLG_CircularBuffer<unsigned long, 10> buffer;
 
 #define BUTTON_PIN A0
 #define INTERVAL 60000

--- a/examples/Interrupts/Interrupts.ino
+++ b/examples/Interrupts/Interrupts.ino
@@ -1,4 +1,4 @@
-#define CIRCULAR_BUFFER_INT_SAFE
+#define RLG_CIRCULAR_BUFFER_INT_SAFE
 #include "CircularBuffer.h"
 CircularBuffer<unsigned long, 10> timings;
 

--- a/examples/Object/Object.ino
+++ b/examples/Object/Object.ino
@@ -1,7 +1,7 @@
-#include <CircularBuffer.h>
+#include <RLG_CircularBuffer.h>
 #include "Record.h"
 
-CircularBuffer<Record*, 10> buffer;
+RLG_CircularBuffer<Record*, 10> buffer;
 
 #define SAMPLE_PIN A0
 

--- a/examples/Queue/Queue.ino
+++ b/examples/Queue/Queue.ino
@@ -1,6 +1,6 @@
-#include <CircularBuffer.h>
+#include <RLG_CircularBuffer.h>
 
-CircularBuffer<int, 100> queue;
+RLG_CircularBuffer<int, 100> queue;
 
 unsigned long time = 0;
 

--- a/examples/Stack/Stack.ino
+++ b/examples/Stack/Stack.ino
@@ -1,6 +1,6 @@
-#include <CircularBuffer.h>
+#include <RLG_CircularBuffer.h>
 
-CircularBuffer<unsigned int, 100> stack;
+RLG_CircularBuffer<unsigned int, 100> stack;
 
 #define SAMPLE_PIN A0
 void setup() {

--- a/examples/Struct/Struct.ino
+++ b/examples/Struct/Struct.ino
@@ -1,4 +1,4 @@
-#include <CircularBuffer.h>
+#include <RLG_CircularBuffer.h>
 
 namespace data {
 	typedef struct {
@@ -16,7 +16,7 @@ namespace data {
 	}
 }
 
-CircularBuffer<data::record, 10> structs;
+RLG_CircularBuffer<data::record, 10> structs;
 
 #define SAMPLE_PIN A0
 

--- a/examples/Test/Test.ino
+++ b/examples/Test/Test.ino
@@ -1,7 +1,7 @@
-#define CIRCULAR_BUFFER_DEBUG
-#include <CircularBuffer.h>
+#define RLG_CIRCULAR_BUFFER_DEBUG
+#include <RLG_CircularBuffer.h>
 
-CircularBuffer<char, 10> buffer;
+RLG_CircularBuffer<char, 10> buffer;
 
 void printBuffer() {
 	if (buffer.isEmpty()) {

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
-name=CircularBuffer
-version=1.3.3
+name=RLG_CircularBuffer
+version=1.4.0
 author=AgileWare
 maintainer=Roberto Lo Giacco <rlogiacco@gmail.com>
 sentence=Arduino circular buffer library
@@ -7,4 +7,4 @@ paragraph=A flexible, compact (~350 bytes overhead) and template based library p
 category=Data Storage
 url=https://github.com/rlogiacco/CircularBuffer
 architectures=*
-includes=CircularBuffer.h
+includes=RLG_CircularBuffer.h


### PR DESCRIPTION
The name `CircularBuffer` is used inside Arduino by some platforms.
Being bundled with a platform gives it higher priority in respect to the user folder library,
causing this library to never be picked up when compiling, for example, for Nano 33 BLE

Renaming the class, adding `RLG_` as prefix prevents the need to use a namespace (difficult to understand for beginners) and lets this compile successfully

addresses #72 