### PR TITLE
Allocate buffer on the heap instead of the stack

### DIFF
--- a/CircularBuffer.h
+++ b/CircularBuffer.h
@@ -69,6 +69,11 @@ public:
 	 */
 	constexpr CircularBuffer();
 
+	/**
+	 * @brief Destroy circular buffer.
+	 */
+	~CircularBuffer();
+
 	// disable the copy constructor
 	/** @private */
 	CircularBuffer(const CircularBuffer&) = delete;
@@ -174,7 +179,7 @@ public:
 	#endif
 
 private:
-	T buffer[S];
+	T *buffer;
 	T *head;
 	T *tail;
 #ifndef CIRCULAR_BUFFER_INT_SAFE

--- a/CircularBuffer.tpp
+++ b/CircularBuffer.tpp
@@ -18,7 +18,12 @@
 
 template<typename T, size_t S, typename IT>
 constexpr CircularBuffer<T,S,IT>::CircularBuffer() :
-		head(buffer), tail(buffer), count(0) {
+		buffer(new T[S]), head(buffer), tail(buffer), count(0) {
+}
+
+template<typename T, size_t S, typename IT>
+CircularBuffer<T,S,IT>::~CircularBuffer() {
+	delete buffer;
 }
 
 template<typename T, size_t S, typename IT>


### PR DESCRIPTION
It's often not desirable to allocate buffers on the stack, particularly for larger buffers which may not be able to fit into a stack frame. This change allocates the buffer on the heap instead of the stack using new