### PR TITLE
Optimize and standardize

### DIFF
--- a/CircularBuffer.hpp
+++ b/CircularBuffer.hpp
@@ -100,14 +100,24 @@ public:
 	 *
 	 * @warning Calling this operation on an empty buffer has an unpredictable behaviour.
 	 */
-	T shift();
+	T&& shift();
+
+	/**
+	 * @brief Removes an element from the beginning of the buffer.
+	 */
+	void shiftNoReturn();
 
 	/**
 	 * @brief Removes an element from the end of the buffer.
 	 *
 	 * @warning Calling this operation on an empty buffer has an unpredictable behaviour.
 	 */
-	T pop();
+	T&& pop();
+
+	/**
+	 * @brief Removes an element from the end of the buffer.
+	 */
+	void popNoReturn();
 
 	/**
 	 * @brief Returns the element at the beginning of the buffer.

--- a/CircularBuffer.hpp
+++ b/CircularBuffer.hpp
@@ -114,14 +114,40 @@ public:
 	 *
 	 * @return The element at the beginning of the buffer.
 	 */
-	T inline first() const;
+	T& first()
+	{
+		return *head;
+	}
+
+	/**
+	 * @brief Returns the element at the beginning of the buffer.
+	 *
+	 * @return The element at the beginning of the buffer.
+	 */
+	const T& first() const
+	{
+		return *head;
+	}
 
 	/**
 	 * @brief Returns the element at the end of the buffer.
 	 *
 	 * @return The element at the end of the buffer.
 	 */
-	T inline last() const;
+	T& last()
+	{
+		return *tail;
+	}
+
+	/**
+	 * @brief Returns the element at the end of the buffer.
+	 *
+	 * @return The element at the end of the buffer.
+	 */
+	const T& last() const
+	{
+		return *tail;
+	}
 
 	/**
 	 * @brief Array-like access to buffer.
@@ -130,7 +156,16 @@ public:
 	 *
 	 * @warning Calling this operation on an empty buffer has an unpredictable behaviour.
 	 */
-	T operator [] (IT index) const;
+	T& operator [] (IT index);
+
+	/**
+	 * @brief Array-like access to buffer.
+	 *
+	 * Calling this operation using and index value greater than `size - 1` returns the tail element.
+	 *
+	 * @warning Calling this operation on an empty buffer has an unpredictable behaviour.
+	 */
+	const T& operator [] (IT index) const;
 
 	/**
 	 * @brief Returns how many elements are actually stored in the buffer.

--- a/CircularBuffer.tpp
+++ b/CircularBuffer.tpp
@@ -60,8 +60,8 @@ bool CircularBuffer<T,S,IT>::push(T value) {
 }
 
 template<typename T, size_t S, typename IT>
-T CircularBuffer<T,S,IT>::shift() {
-	if (count == 0) return *head;
+T&& CircularBuffer<T,S,IT>::shift() {
+	if (count == 0) return std::move(*head);
 	T&& result = std::move(*(head++));
 	if (head >= buffer + capacity) {
 		head = buffer;
@@ -71,14 +71,32 @@ T CircularBuffer<T,S,IT>::shift() {
 }
 
 template<typename T, size_t S, typename IT>
-T CircularBuffer<T,S,IT>::pop() {
-	if (count == 0) return *tail;
+void CircularBuffer<T,S,IT>::shiftNoReturn() {
+	if (count == 0) return;
+	if (++head >= buffer + capacity) {
+		head = buffer;
+	}
+	count--;
+}
+
+template<typename T, size_t S, typename IT>
+T&& CircularBuffer<T,S,IT>::pop() {
+	if (count == 0) return std::move(*tail);
 	T&& result = std::move(*(tail--));
 	if (tail < buffer) {
 		tail = buffer + capacity - 1;
 	}
 	count--;
 	return std::move(result);
+}
+
+template<typename T, size_t S, typename IT>
+void CircularBuffer<T,S,IT>::popNoReturn() {
+	if (count == 0) return;
+	if (--tail < buffer) {
+		tail = buffer + capacity - 1;
+	}
+	count--;
 }
 
 template<typename T, size_t S, typename IT>

--- a/CircularBuffer.tpp
+++ b/CircularBuffer.tpp
@@ -26,7 +26,7 @@ bool CircularBuffer<T,S,IT>::unshift(T value) {
 	if (head == buffer) {
 		head = buffer + capacity;
 	}
-	*--head = value;
+	*--head = std::move(value);
 	if (count == capacity) {
 		if (tail-- == buffer) {
 			tail = buffer + capacity - 1;
@@ -45,7 +45,7 @@ bool CircularBuffer<T,S,IT>::push(T value) {
 	if (++tail == buffer + capacity) {
 		tail = buffer;
 	}
-	*tail = value;
+	*tail = std::move(value);
 	if (count == capacity) {
 		if (++head == buffer + capacity) {
 			head = buffer;
@@ -62,37 +62,33 @@ bool CircularBuffer<T,S,IT>::push(T value) {
 template<typename T, size_t S, typename IT>
 T CircularBuffer<T,S,IT>::shift() {
 	if (count == 0) return *head;
-	T result = *head++;
+	T&& result = std::move(*(head++));
 	if (head >= buffer + capacity) {
 		head = buffer;
 	}
 	count--;
-	return result;
+	return std::move(result);
 }
 
 template<typename T, size_t S, typename IT>
 T CircularBuffer<T,S,IT>::pop() {
 	if (count == 0) return *tail;
-	T result = *tail--;
+	T&& result = std::move(*(tail--));
 	if (tail < buffer) {
 		tail = buffer + capacity - 1;
 	}
 	count--;
-	return result;
+	return std::move(result);
 }
 
 template<typename T, size_t S, typename IT>
-T inline CircularBuffer<T,S,IT>::first() const {
-	return *head;
+T& CircularBuffer<T,S,IT>::operator [](IT index) {
+	if (index >= count) return *tail;
+	return *(buffer + ((head - buffer + index) % capacity));
 }
 
 template<typename T, size_t S, typename IT>
-T inline CircularBuffer<T,S,IT>::last() const {
-	return *tail;
-}
-
-template<typename T, size_t S, typename IT>
-T CircularBuffer<T,S,IT>::operator [](IT index) const {
+const T& CircularBuffer<T,S,IT>::operator [](IT index) const {
 	if (index >= count) return *tail;
 	return *(buffer + ((head - buffer + index) % capacity));
 }

--- a/CircularBuffer.tpp
+++ b/CircularBuffer.tpp
@@ -26,7 +26,7 @@ bool CircularBuffer<T,S,IT>::unshift(T value) {
 	if (head == buffer) {
 		head = buffer + capacity;
 	}
-	*--head = std::move(value);
+	*(--head) = std::move(value);
 	if (count == capacity) {
 		if (tail-- == buffer) {
 			tail = buffer + capacity - 1;


### PR DESCRIPTION
* Adds multiple overloads for head and tail getters.
* Uses move semantics in places that make sense.
* Adds no-return variants of `shift` and `pop`
* Adds const ref overloads for operator []